### PR TITLE
Add error reporting

### DIFF
--- a/examples/thermometer.rs
+++ b/examples/thermometer.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 use embassy_executor::Spawner;
-use esp_backtrace as _;
-use esp_println::println;
 use embassy_time::{Duration, Timer};
-use esp_hal::{rmt::*, timer::systimer::SystemTimer, clock::CpuClock, time::Rate};
+use esp_backtrace as _;
+use esp_hal::{clock::CpuClock, rmt::*, time::Rate, timer::systimer::SystemTimer};
 use esp_hal_rmt_onewire::*;
+use esp_println::println;
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) -> ! {
@@ -13,10 +13,12 @@ async fn main(_spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(config);
     let timer0 = SystemTimer::new(peripherals.SYSTIMER);
     esp_hal_embassy::init(timer0.alarm0);
-    
-    let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(80_u32)).unwrap().into_async();
+
+    let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(80_u32))
+        .unwrap()
+        .into_async();
     let mut ow = OneWire::new(rmt.channel0, rmt.channel2, peripherals.GPIO6).unwrap();
-    
+
     loop {
         println!("Resetting the bus");
         ow.reset().await.unwrap();
@@ -58,8 +60,14 @@ pub async fn search<R: RxChannelAsync, T: TxChannelAsync>(ow: &mut OneWire<R, T>
                 ow.send_byte(0x55).await.unwrap();
                 ow.send_address(address).await.unwrap();
                 ow.send_byte(0xBE).await.unwrap();
-                let temp_low = ow.exchange_byte(0xFF).await.expect("failed to get low byte of temperature");
-                let temp_high = ow.exchange_byte(0xFF).await.expect("failed to get high byte of temperature");
+                let temp_low = ow
+                    .exchange_byte(0xFF)
+                    .await
+                    .expect("failed to get low byte of temperature");
+                let temp_high = ow
+                    .exchange_byte(0xFF)
+                    .await
+                    .expect("failed to get high byte of temperature");
                 let temp = fixed::types::I12F4::from_le_bytes([temp_low, temp_high]);
                 println!("Temp is: {temp}");
             }


### PR DESCRIPTION
Handle most of the obvious errors the crate could encounter. This could be more careful about checking that the bus is actually high before starting a transaction, but errors from the RMT peripheral will propagate and the hang where the receive side never fires an interrupt but the transmission side is done instead times out with an error.